### PR TITLE
[Feature] customizable profiling depth.

### DIFF
--- a/torchprof/profile.py
+++ b/torchprof/profile.py
@@ -5,25 +5,19 @@ from collections import namedtuple, defaultdict, OrderedDict
 Trace = namedtuple("Trace", ["path", "leaf", "module"])
 Measure = namedtuple("Measure", ["self_cpu_total", "cpu_total", "cuda_total", "occurrences"])
 
-CurDepth = 0
-
 
 def walk_modules(module, name="", path=(), depth=-1):
     """Generator. Walks through a PyTorch Module and outputs Trace tuples"""
-    global CurDepth
-    CurDepth += 1
-
     if not name:
         name = module.__class__.__name__
     named_children = list(module.named_children())
     path = path + (name,)
-    yield Trace(path, len(named_children) == 0 or (CurDepth > depth and depth != -1), module)
+    yield Trace(path, len(named_children) == 0 or (len(path) > depth and depth != -1), module)
 
-    if CurDepth <= depth or depth == -1:
+    if len(path) <= depth or depth == -1:
         # recursively walk into all submodules
         for name, child_module in named_children:
             yield from walk_modules(child_module, name=name, path=path, depth=depth)
-    CurDepth -= 1
 
 
 class Profile(object):


### PR DESCRIPTION
I am not sure whether this is a useful feature for other users. At least, it is very important feature for me to be able to profile module in customized depth.

# Show case
## Profiling with default setting (go all the way to the leaf module)
```python
import torch
import torchprof
from torchvision.models import resnet50

net = resnet50()
with torchprof.Profile(net) as prof:
    net(torch.randn(1, 3, 224, 224))
print(prof.display())
```
```
Module           | Self CPU total | CPU total | CUDA total | Occurrences
-----------------|----------------|-----------|------------|------------
ResNet           |                |           |            |
├── conv1        |        7.120ms |  28.385ms |    0.000us |           1
├── bn1          |        3.274ms |   9.720ms |    0.000us |           1
├── relu         |      277.000us | 277.000us |    0.000us |           1
├── maxpool      |       10.684ms |  21.350ms |    0.000us |           1
├── layer1       |                |           |            |
│├── 0           |                |           |            |
││├── conv1      |        2.264ms |   9.026ms |    0.000us |           1
││├── bn1        |        1.031ms |   3.057ms |    0.000us |           1
││├── conv2      |        5.019ms |  20.043ms |    0.000us |           1
││├── bn2        |        1.035ms |   3.069ms |    0.000us |           1
││├── conv3      |        6.099ms |  24.366ms |    0.000us |           1
││├── bn3        |        4.106ms |  12.280ms |    0.000us |           1
││├── relu       |      380.000us | 380.000us |    0.000us |           3
.
.
.
```
## Profiling the root module (`depth=0`)
```python
import torch
import torchprof
from torchvision.models import resnet50

net = resnet50()
with torchprof.Profile(net, depth=0) as prof:
    net(torch.randn(1, 3, 224, 224))
print(prof.display())
```
```
Module | Self CPU total | CPU total | CUDA total | Occurrences
-------|----------------|-----------|------------|------------
ResNet |      416.115ms |    1.452s |    0.000us |           1
```
## Profiling the a level below the root module (`depth=1`).
```python
import torch
import torchprof
from torchvision.models import resnet50

net = resnet50()
with torchprof.Profile(net, depth=1) as prof:
    net(torch.randn(1, 3, 224, 224))
print(prof.display())
```
```
Module      | Self CPU total | CPU total | CUDA total | Occurrences
------------|----------------|-----------|------------|------------
ResNet      |                |           |            |
├── conv1   |        7.847ms |  31.282ms |    0.000us |           1
├── bn1     |        3.327ms |   9.874ms |    0.000us |           1
├── relu    |      426.000us | 426.000us |    0.000us |           1
├── maxpool |       11.048ms |  22.075ms |    0.000us |           1
├── layer1  |       69.861ms | 249.340ms |    0.000us |           1
├── layer2  |       82.249ms | 296.856ms |    0.000us |           1
├── layer3  |      114.647ms | 403.939ms |    0.000us |           1
├── layer4  |      106.572ms | 374.676ms |    0.000us |           1
├── avgpool |      233.000us | 424.000us |    0.000us |           1
└── fc      |        2.184ms |   2.184ms |    0.000us |           1
```