### PR TITLE
Update to work with PyTorch 1.8

### DIFF
--- a/torchprof/profile.py
+++ b/torchprof/profile.py
@@ -87,7 +87,10 @@ class Profile(object):
                         res = _forward(*args, **kwargs)
 
                 event_list = prof.function_events
-                event_list.populate_cpu_children()
+                # PyTorch up until version 1.7 exposes this method. From PyTorch 1.8 onwards, 
+                # it is called via EventList._build_tree at the end of the context manager.
+                if hasattr(event_list, "populate_cpu_children"):
+                    event_list.populate_cpu_children()
                 # each profile call should be contained in its own list
                 self.trace_profile_events[path].append(event_list)
                 return res


### PR DESCRIPTION
PyTorch 1.8 has deprecated the `populate_cpu_children` method in [PR 46470](https://github.com/pytorch/pytorch/pull/46470/files#diff-8137a27af89ba1dbfa19eecc4b12036ea20d78cbb96d7b541a814e014646a087R72). To make the code backwards compatible, only call `populate_cpu_children` if it is available. Otherwise, assume that the code is PyTorch >=1.8, and simply not call it.
Closes #18 